### PR TITLE
fix: fixed codesandbox.templates doesn't work

### DIFF
--- a/packages/plugin/src/components/index.vue
+++ b/packages/plugin/src/components/index.vue
@@ -305,7 +305,7 @@ watch(
             :code="currentCode"
             :type="type"
             :scope="scope || ''"
-            :templates="stackblitz.templates || []"
+            :templates="codesandbox.templates || []"
           />
         </Tooltip>
         <Tooltip content="在 github 中打开" v-if="github">


### PR DESCRIPTION
`CodeSandboxIcon`在传`templates`参数时传成了`stackblitz.templates`导致配置了`codesandbox.templates`不生效。