### PR TITLE
feat:support using defineClientComponent for vue component preview

### DIFF
--- a/packages/plugin/src/markdown/preview.ts
+++ b/packages/plugin/src/markdown/preview.ts
@@ -24,6 +24,7 @@ const vueFilesRegex = /vueFiles=("\{((.|\n)*?)\}"|"\[((.|\n)*?)\]")/;
 const reactFilesRegex = /reactFiles=("\{((.|\n)*?)\}"|"\[((.|\n)*?)\]")/;
 const htmlFilesRegex = /htmlFiles=("\{((.|\n)*?)\}"|"\[((.|\n)*?)\]")/;
 const ssgRegex = /ssg="(.*?)"/;
+const vueDefineClientRegex = /vue-define-client="(.*?)"/;
 
 export interface DefaultProps {
   title?: string;
@@ -176,6 +177,7 @@ export const transformPreview = (
   const reactFilesValue = token.content.match(reactFilesRegex);
   const htmlFilesValue = token.content.match(htmlFilesRegex);
   const ssgValue = !!token.content.match(ssgRegex)?.[1];
+  const vueDefineClientValue = !!token.content.match(vueDefineClientRegex)?.[1];
   const dirPath = demoDir || path.dirname(mdFile.path);
 
   if (orderValue?.[1]) {
@@ -272,7 +274,15 @@ export const transformPreview = (
 
   // 注入组件导入语句
   if (componentProps.vue) {
-    injectComponentImportScript(mdFile, componentVuePath, componentName);
+    if (vueDefineClientValue) {
+      injectComponentImportScript(mdFile, 'vitepress', '{ defineClientComponent }')
+    }
+    injectComponentImportScript(
+      mdFile,
+      componentVuePath,
+      componentName,
+      vueDefineClientValue ? 'defineClientComponent' : undefined,
+    )
   }
   if (componentProps.react) {
     injectComponentImportScript(

--- a/packages/plugin/src/markdown/utils.ts
+++ b/packages/plugin/src/markdown/utils.ts
@@ -19,7 +19,7 @@ export const injectComponentImportScript = (
   env: any,
   path: string,
   name?: string,
-  type?: 'dynamicImport' | 'inject',
+  type?: 'dynamicImport' | 'inject' | 'defineClientComponent',
 ) => {
   const scriptsCode = env.sfcBlocks.scripts as any[];
 
@@ -53,6 +53,10 @@ export const injectComponentImportScript = (
   } else if (type === 'inject') {
     importCode = `
       ${name}
+    `.trim();
+  } else if (type === 'defineClientComponent') {
+    importCode = `
+      const ${componentName} = defineClientComponent(() => import('${path}'))
     `.trim();
   } else {
     importCode = name


### PR DESCRIPTION
## Background

`<ClientOnly>` 构建时可能仍然导致报错

```
✖ rendering pages...
build error:
Cannot find module '/Users/gene/Projects/vue-test-ts/node_modules/.pnpm/@opentiny+vue-button@3.22.0/node_modules/@opentiny/vue-renderless/button/vue' imported from /Users/gene/Projects/vue-test-ts/node_modules/.pnpm/@opentiny+vue-button@3.22.0/node_modules/@opentiny/vue-button/lib/pc.js
Did you mean to import "@opentiny/vue-renderless/button/vue.js"?
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/gene/Projects/vue-test-ts/node_modules/.pnpm/@opentiny+vue-button@3.22.0/node_modules/@opentiny/vue-renderless/button/vue' imported from /Users/gene/Projects/vue-test-ts/node_modules/.pnpm/@opentiny+vue-button@3.22.0/node_modules/@opentiny/vue-button/lib/pc.js
Did you mean to import "@opentiny/vue-renderless/button/vue.js"?
    at finalizeResolution (node:internal/modules/esm/resolve:283:11)
    at moduleResolve (node:internal/modules/esm/resolve:952:10)
    at defaultResolve (node:internal/modules/esm/resolve:1188:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:642:12)
    at #cachedDefaultResolve (node:internal/modules/esm/loader:591:25)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:574:38)
    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:236:38)
    at ModuleJob._link (node:internal/modules/esm/module_job:130:49)
 ELIFECYCLE  Command failed with exit code 1.
```

示例代码如下
```vue
// ../demos/demo.vue
<template>
  <tiny-button>Button</tiny-button>
</template>

<script setup lang="ts">
import TinyButton from "@opentiny/vue-button";
</script>
```

Markdown中使用
```markdown
<demo vue="../demos/demo.vue"/>
```

## Solution

使用 [defineClientComponent](https://vitepress.dev/zh/guide/ssr-compat#defineclientcomponent) 导入 vue 组件，给 `demo` 组件新增一个属性 `vue-define-client`

Markdown中使用增加 vue-define-client 属性即可
```markdown
<demo vue="../demos/demo.vue" vue-define-client="true"/>
```