### PR TITLE
fix: use realPath to get correct demo path when set rewrites

### DIFF
--- a/packages/plugin/src/components/tooltip/index.vue
+++ b/packages/plugin/src/components/tooltip/index.vue
@@ -43,4 +43,3 @@ const props = defineProps<{
   display: none;
 }
 </style>
-../utils/namespace

--- a/packages/plugin/src/markdown/preview.ts
+++ b/packages/plugin/src/markdown/preview.ts
@@ -179,7 +179,7 @@ export const transformPreview = (
   const ssgValue = !!token.content.match(ssgRegex)?.[1];
   const htmlWriteWayValue =
     token.content.match(htmlWriteWayRegex)?.[1] || 'write';
-  const dirPath = demoDir || path.dirname(mdFile.path);
+  const dirPath = demoDir || path.dirname(mdFile.realPath);
 
   if (orderValue?.[1]) {
     order = orderValue[1];
@@ -230,7 +230,7 @@ export const transformPreview = (
   const componentVuePath = componentProps.vue
     ? path
         .resolve(
-          demoDir || path.dirname(mdFile.path),
+          demoDir || path.dirname(mdFile.realPath),
           vuePathRegexValue?.[1] || '.'
         )
         .replace(/\\/g, '/')
@@ -238,7 +238,7 @@ export const transformPreview = (
   const componentHtmlPath = componentProps.html
     ? path
         .resolve(
-          demoDir || path.dirname(mdFile.path),
+          demoDir || path.dirname(mdFile.realPath),
           htmlPathRegexValue?.[1] || '.'
         )
         .replace(/\\/g, '/')
@@ -246,7 +246,7 @@ export const transformPreview = (
   const componentReactPath = componentProps.react
     ? path
         .resolve(
-          demoDir || path.dirname(mdFile.path),
+          demoDir || path.dirname(mdFile.realPath),
           reactPathRegexValue?.[1] || '.'
         )
         .replace(/\\/g, '/')
@@ -392,7 +392,7 @@ export const transformPreview = (
           const filePath = files[key as keyof typeof files][file].filename;
           if (filePath) {
             const absPath = path
-              .resolve(demoDir || path.dirname(mdFile.path), filePath || '.')
+              .resolve(demoDir || path.dirname(mdFile.realPath), filePath || '.')
               .replace(/\\/g, '/');
             if (fs.existsSync(absPath)) {
               const code = fs.readFileSync(absPath, 'utf-8');

--- a/packages/plugin/src/markdown/preview.ts
+++ b/packages/plugin/src/markdown/preview.ts
@@ -179,7 +179,8 @@ export const transformPreview = (
   const ssgValue = !!token.content.match(ssgRegex)?.[1];
   const htmlWriteWayValue =
     token.content.match(htmlWriteWayRegex)?.[1] || 'write';
-  const dirPath = demoDir || path.dirname(mdFile.realPath);
+  const mdFilePath = mdFile.realPath ?? mdFile.path;
+  const dirPath = demoDir || path.dirname(mdFilePath);
 
   if (orderValue?.[1]) {
     order = orderValue[1];
@@ -230,7 +231,7 @@ export const transformPreview = (
   const componentVuePath = componentProps.vue
     ? path
         .resolve(
-          demoDir || path.dirname(mdFile.realPath),
+          demoDir || path.dirname(mdFilePath),
           vuePathRegexValue?.[1] || '.'
         )
         .replace(/\\/g, '/')
@@ -238,7 +239,7 @@ export const transformPreview = (
   const componentHtmlPath = componentProps.html
     ? path
         .resolve(
-          demoDir || path.dirname(mdFile.realPath),
+          demoDir || path.dirname(mdFilePath),
           htmlPathRegexValue?.[1] || '.'
         )
         .replace(/\\/g, '/')
@@ -246,7 +247,7 @@ export const transformPreview = (
   const componentReactPath = componentProps.react
     ? path
         .resolve(
-          demoDir || path.dirname(mdFile.realPath),
+          demoDir || path.dirname(mdFilePath),
           reactPathRegexValue?.[1] || '.'
         )
         .replace(/\\/g, '/')
@@ -392,7 +393,7 @@ export const transformPreview = (
           const filePath = files[key as keyof typeof files][file].filename;
           if (filePath) {
             const absPath = path
-              .resolve(demoDir || path.dirname(mdFile.realPath), filePath || '.')
+              .resolve(demoDir || path.dirname(mdFilePath), filePath || '.')
               .replace(/\\/g, '/');
             if (fs.existsSync(absPath)) {
               const code = fs.readFileSync(absPath, 'utf-8');


### PR DESCRIPTION
当配置了路由重写时，类似这样`<demo vue="./demo/base.vue" />`会无法获取到正确的demo路径，原因是因为在处理path时默认使用了`mdFile.path`，会受路由重写的影响，因此改为`realPath`获取真实的路径就行了。