### PR TITLE
refactor: split markdown preview utilities

### DIFF
--- a/packages/plugin/src/markdown/preview.ts
+++ b/packages/plugin/src/markdown/preview.ts
@@ -2,147 +2,30 @@
 import MarkdownIt from 'markdown-it';
 import Token from 'markdown-it/lib/token';
 import path from 'path';
-import fs from 'fs';
-import { composeComponentName, injectComponentImportScript } from './utils';
-import { PlatformTemplate } from '../constant/type';
-import { Locale } from '@/locales/text';
+import {
+  composeComponentName,
+  createPlaygroundUrls,
+  getAbsolutePath,
+  injectComponentImportScript,
+  parsePreviewAttributes,
+  readPreviewFiles,
+} from './utils';
+import type {
+  DefaultProps,
+  Playground,
+  VitepressDemoBoxConfig,
+} from './utils';
 
-const titleRegex = /title="(.*?)"/;
-const vuePathRegex = /vue="(.*?)"/;
-const htmlPathRegex = /html="(.*?)"/;
-const reactPathRegex = /react="(.*?)"/;
-const descriptionRegex = /description="(.*?)"/;
-const orderRegex = /order="(.*?)"/;
-const selectRegex = /select="(.*?)"/;
-const githubRegex = /github="(.*?)"/;
-const gitlabRegex = /gitlab="(.*?)"/;
-const stackblitzRegex = /stackblitz="(.*?)"/;
-const codesandboxRegex = /codesandbox="(.*?)"/;
-const scopeRegex = /scope="(.*?)"/;
-const vueFilesRegex = /vueFiles=("\{((.|\n)*?)\}"|"\[((.|\n)*?)\]")/;
-const reactFilesRegex = /reactFiles=("\{((.|\n)*?)\}"|"\[((.|\n)*?)\]")/;
-const htmlFilesRegex = /htmlFiles=("\{((.|\n)*?)\}"|"\[((.|\n)*?)\]")/;
-const ssgRegex = /ssg="(.*?)"/;
-const htmlWriteWayRegex = /htmlWriteWay="(.*?)"/;
-const backgroundRegex = /background="(.*?)"/;
-const playgroundRegex = /playground="(.*?)"/;
-
-const getRelativePath = (from: string, to: string) =>
-  path.relative(from, to).replace(/\\/g, '/');
-
-export interface DefaultProps {
-  title?: string;
-  description?: string;
-  vue?: string;
-  html?: string;
-  react?: string;
-}
-
-export interface TabConfig {
-  /**
-   * @cn 代码切换 tab 的展示顺序
-   * @en The order of the code switch tab
-   */
-  order?: string;
-  /**
-   * @cn 是否显示 tab
-   * @en Whether to show the tab
-   */
-  visible?: boolean;
-  /**
-   * @cn 默认选中的 tab
-   * @en The default selected tab
-   */
-  select?: string;
-}
-
-export type Files = Record<string, { code: string; filename: string }>;
-
-export type Platform = {
-  show: boolean;
-  templates?: PlatformTemplate[];
-};
-
-export type CodeFiles = string[] | Record<string, string>;
-
-export type PlaygroundConfig = {
-  url: string | ((content: string) => string);
-  fn?: (files: Record<string, string>) => string;
-  entryName?: {
-    vue?: string;
-    react?: string;
-    html?: string;
-  };
-};
-
-export type Playground = {
-  show: boolean;
-  templates?: PlatformTemplate[];
-  config: PlaygroundConfig | (PlaygroundConfig & { name: string })[];
-};
-
-export interface VitepressDemoBoxConfig {
-  /**
-   * @cn demo所在目录
-   * @en The directory of the demo
-   */
-  demoDir?: string;
-  /**
-   * @cn 代码切换 tab 的配置
-   * @en The configuration of the code switch tab
-   */
-  tab?: TabConfig;
-  /**
-   * @cn stackblitz 平台配置
-   * @en The configuration of the stackblitz platform
-   */
-  stackblitz?: Platform;
-  /**
-   * @cn codesandbox 平台配置
-   * @en The configuration of the codesandbox platform
-   */
-  codesandbox?: Platform;
-  /**
-   * @cn vue 展示的代码文件
-   * @en The code files of the vue
-   */
-  vueFiles?: CodeFiles;
-  /**
-   * @cn react 展示的代码文件
-   * @en The code files of the react
-   */
-  reactFiles?: CodeFiles;
-  /**
-   * @cn html 展示的代码文件
-   * @en The code files of the html
-   */
-  htmlFiles?: CodeFiles;
-  /**
-   * @cn 亮色模式主题，参考 https://shiki.style/themes#bundled-themes
-   * @en The light theme, reference https://shiki.style/themes#bundled-themes
-   */
-  lightTheme?: string;
-  /**
-   * @cn 暗色模式主题，参考 https://shiki.style/themes#bundled-themes
-   * @en The dark theme, reference https://shiki.style/themes#bundled-themes
-   */
-  darkTheme?: string;
-  /**
-   * @cn 亮色/暗色模式统一的主题(建议使用 lightTheme 和 darkTheme 分开)，参考 https://shiki.style/themes#bundled-themes
-   * @en The light/dark theme, reference https://shiki.style/themes#bundled-themes
-   */
-  theme?: string;
-  /**
-   * @cn 国际化配置 'zh-CN' | 'en-US'
-   * @en The locale configuration 'zh-CN' | 'en-US'
-   */
-  locale?: Locale;
-  /**
-   * @cn 自定义 playground 平台配置
-   * @en The configuration of the custom playground platform
-   */
-  playground?: Playground;
-}
+export type {
+  CodeFiles,
+  DefaultProps,
+  Files,
+  Platform,
+  Playground,
+  PlaygroundConfig,
+  TabConfig,
+  VitepressDemoBoxConfig,
+} from './utils';
 
 /**
  * 编译预览组件
@@ -170,99 +53,58 @@ export const transformPreview = (
     visible = true,
     select = (tab.order || 'vue,react,html').split(',')[0] || 'vue',
   } = tab;
-
-  const componentProps: DefaultProps = {
-    vue: '',
-    title: '',
-    description: '',
-    html: '',
-    react: '',
-  };
-
-  // 获取Props相关参数
-  const titleValue = token.content.match(titleRegex);
-  const vuePathRegexValue = token.content.match(vuePathRegex);
-  const htmlPathRegexValue = token.content.match(htmlPathRegex);
-  const reactPathRegexValue = token.content.match(reactPathRegex);
-  const descriptionRegexValue = token.content.match(descriptionRegex);
-  const orderValue = token.content.match(orderRegex);
-  const selectValue = token.content.match(selectRegex);
-  const githubValue = token.content.match(githubRegex);
-  const gitlabValue = token.content.match(gitlabRegex);
-  const stackblitzValue = token.content.match(stackblitzRegex);
-  const codesandboxValue = token.content.match(codesandboxRegex);
-  const scopeValue = token.content.match(scopeRegex)?.[1] || '';
-  const vueFilesValue = token.content.match(vueFilesRegex);
-  const reactFilesValue = token.content.match(reactFilesRegex);
-  const htmlFilesValue = token.content.match(htmlFilesRegex);
-  const ssgValue = !!token.content.match(ssgRegex)?.[1];
-  const htmlWriteWayValue =
-    token.content.match(htmlWriteWayRegex)?.[1] || 'write';
-  const backgroundValue = token.content.match(backgroundRegex)?.[1];
+  const attributes = parsePreviewAttributes(token.content);
+  const {
+    github,
+    gitlab,
+    scope: scopeValue,
+    ssg: ssgValue,
+    htmlWriteWay: htmlWriteWayValue,
+    background: backgroundValue,
+  } = attributes;
   const mdFilePath = mdFile.realPath ?? mdFile.path;
   const dirPath = demoDir || path.dirname(mdFilePath);
-  const playgroundValue = token.content.match(playgroundRegex);
 
-  if (orderValue?.[1]) {
-    order = orderValue[1];
+  if (attributes.order) {
+    order = attributes.order;
   }
-  if (selectValue?.[1]) {
-    select = selectValue[1];
+  if (attributes.select) {
+    select = attributes.select;
   }
-  let github = '';
-  let gitlab = '';
-  if (githubValue?.[1]) {
-    github = githubValue[1];
+  if (attributes.stackblitz) {
+    stackblitz.show = attributes.stackblitz === 'true';
   }
-  if (gitlabValue?.[1]) {
-    gitlab = gitlabValue[1];
+  if (attributes.codesandbox) {
+    codesandbox.show = attributes.codesandbox === 'true';
   }
-  if (stackblitzValue?.[1]) {
-    stackblitz.show = stackblitzValue[1] === 'true';
-  }
-  if (codesandboxValue?.[1]) {
-    codesandbox.show = codesandboxValue[1] === 'true';
-  }
-  if (playgroundValue?.[1]) {
-    playground.show = playgroundValue[1] !== 'false';
+  if (attributes.playground) {
+    playground.show = attributes.playground !== 'false';
   }
 
-  if (vuePathRegexValue?.[1]) {
-    componentProps.vue = path
-      .join(dirPath, vuePathRegexValue[1])
-      .replace(/\\/g, '/');
-  }
-
-  if (htmlPathRegexValue?.[1]) {
-    componentProps.html = path
-      .join(dirPath, htmlPathRegexValue[1])
-      .replace(/\\/g, '/');
-  }
-  if (reactPathRegexValue?.[1]) {
-    componentProps.react = path
-      .join(dirPath, reactPathRegexValue[1])
-      .replace(/\\/g, '/');
-  }
-
-  componentProps.title = titleValue ? titleValue[1] : '';
-  componentProps.description = descriptionRegexValue
-    ? descriptionRegexValue[1]
-    : '';
-
-  const getAbsPath = (demoPath?: string) => {
-    return path
-      .resolve(demoDir || path.dirname(mdFilePath), demoPath || '.')
-      .replace(/\\/g, '/');
+  const componentProps: DefaultProps = {
+    title: attributes.title,
+    description: attributes.description,
+    vue: attributes.vuePath
+      ? path.join(dirPath, attributes.vuePath).replace(/\\/g, '/')
+      : '',
+    html: attributes.htmlPath
+      ? path.join(dirPath, attributes.htmlPath).replace(/\\/g, '/')
+      : '',
+    react: attributes.reactPath
+      ? path.join(dirPath, attributes.reactPath).replace(/\\/g, '/')
+      : '',
   };
 
+  const getAbsPath = (demoPath?: string) =>
+    getAbsolutePath(demoDir || path.dirname(mdFilePath), demoPath);
   const componentVuePath = componentProps.vue
-    ? getAbsPath(vuePathRegexValue?.[1])
+    ? getAbsPath(attributes.vuePath)
     : '';
   const componentHtmlPath = componentProps.html
-    ? getAbsPath(htmlPathRegexValue?.[1])
+    ? getAbsPath(attributes.htmlPath)
     : '';
   const componentReactPath = componentProps.react
-    ? getAbsPath(reactPathRegexValue?.[1])
+    ? getAbsPath(attributes.reactPath)
     : '';
 
   // 组件名
@@ -356,81 +198,17 @@ export const transformPreview = (
     );
   }
 
-  // 多文件展示
-  const files = {
-    vue: {} as Record<string, { code: string; filename: string }>,
-    react: {} as Record<string, { code: string; filename: string }>,
-    html: {} as Record<string, { code: string; filename: string }>,
-  };
-
-  function formatString(value: string) {
-    return value
-      .replace(/'/g, '"')
-      .replace(/\\n/g, '')
-      .trim()
-      .replace(/^"/, '')
-      .replace(/"$/, '')
-      .replace(/,(\s|\n)*\}$/, '}')
-      .replace(/,(\s|\n)*\]$/, ']');
-  }
-
   const inputFiles = {
-    vue: formatString(vueFilesValue?.[1] || ''),
-    react: formatString(reactFilesValue?.[1] || ''),
-    html: formatString(htmlFilesValue?.[1] || ''),
+    vue: attributes.vueFiles,
+    react: attributes.reactFiles,
+    html: attributes.htmlFiles,
   };
-
-  for (const key in inputFiles) {
-    let value = inputFiles[key as keyof typeof inputFiles];
-    if (value) {
-      try {
-        const codeFiles = JSON.parse(value);
-        if (Array.isArray(codeFiles)) {
-          (codeFiles as string[]).forEach((file) => {
-            const filePath = getAbsPath(file);
-            const componentMap = {
-              html: componentHtmlPath,
-              vue: componentVuePath,
-              react: componentReactPath,
-            };
-            const fileName = getRelativePath(
-              path.dirname(componentMap[key as keyof typeof componentMap]),
-              filePath,
-            );
-            files[key as keyof typeof files][fileName] = {
-              filename: file,
-              code: '',
-            };
-          });
-        } else if (typeof codeFiles === 'object') {
-          for (const file in codeFiles) {
-            files[key as keyof typeof files][file] = {
-              filename: codeFiles[file],
-              code: '',
-            };
-          }
-        }
-        for (const file in files[key as keyof typeof files]) {
-          const filePath = files[key as keyof typeof files][file].filename;
-          if (filePath) {
-            const absPath = path
-              .resolve(demoDir || path.dirname(mdFilePath), filePath || '.')
-              .replace(/\\/g, '/');
-            if (fs.existsSync(absPath)) {
-              const code = fs.readFileSync(absPath, 'utf-8');
-              files[key as keyof typeof files][file].code = code;
-            } else {
-              delete files[key as keyof typeof files][file];
-            }
-          } else {
-            delete files[key as keyof typeof files][file];
-          }
-        }
-      } catch (error) {
-        // 格式错误，则不展示该文件
-      }
-    }
-  }
+  const componentPaths = {
+    vue: componentVuePath,
+    react: componentReactPath,
+    html: componentHtmlPath,
+  };
+  const files = readPreviewFiles(inputFiles, componentPaths, dirPath);
 
   // 国际化
   let locale = '';
@@ -438,126 +216,19 @@ export const transformPreview = (
     locale = encodeURIComponent(JSON.stringify(config.locale));
   }
 
-  let htmlPlayground = '';
-  let vuePlayground = '';
-  let reactPlayground = '';
-  // Helper functions for base64 encoding/decoding
-  const utoa = (data: string): string =>
-    btoa(unescape(encodeURIComponent(data)));
-
-  (() => {
-    try {
-      if (!playground?.show) {
-        return;
-      }
-      const globalFiles = (playground.templates || []).find(
-        (item) => item.scope === 'global',
-      )?.files;
-      const scopeFiles = (playground.templates || []).find(
-        (item) => item.scope === scopeValue,
-      )?.files;
-      const htmlFiles = {
-        ...(playground.templates || []).find((item) => item.scope === 'html')
-          ?.files,
-      };
-      const vueFiles = {
-        ...(playground.templates || []).find((item) => item.scope === 'vue')
-          ?.files,
-      };
-      const reactFiles = {
-        ...(playground.templates || []).find((item) => item.scope === 'react')
-          ?.files,
-      };
-      if (htmlFilesValue) {
-        Object.entries(files.html || {}).forEach(([_, item]) => {
-          const filePath = getAbsPath(item.filename);
-          if (filePath === componentHtmlPath) {
-            return;
-          }
-          const dir = path.dirname(componentHtmlPath);
-          const filename = getRelativePath(dir, filePath);
-          htmlFiles[filename] = item.code;
-        });
-      }
-      if (vueFilesValue) {
-        Object.entries(files.vue || {}).forEach(([_, item]) => {
-          const filePath = getAbsPath(item.filename);
-          if (filePath === componentVuePath) {
-            return;
-          }
-          const dir = path.dirname(componentVuePath);
-          const filename = getRelativePath(dir, filePath);
-          vueFiles[filename] = item.code;
-        });
-      }
-      if (reactFilesValue) {
-        Object.entries(files.react || {}).forEach(([_, item]) => {
-          const filePath = getAbsPath(item.filename);
-          if (filePath === componentReactPath) {
-            return;
-          }
-          const dir = path.dirname(componentReactPath);
-          const filename = getRelativePath(dir, filePath);
-          reactFiles[filename] = item.code;
-        });
-      }
-
-      const playgroundConfig = Array.isArray(playground.config)
-        ? playground.config.find(
-            (config) => config.name === playgroundValue?.[1],
-          )
-        : playground.config;
-      if (!playgroundConfig || !playgroundConfig.url) {
-        return;
-      }
-
-      if (componentHtmlPath) {
-        htmlFiles[playgroundConfig.entryName?.html || 'index.html'] =
-          fs.readFileSync(componentHtmlPath, 'utf-8');
-      }
-      if (componentVuePath) {
-        vueFiles[playgroundConfig.entryName?.vue || 'App.vue'] =
-          fs.readFileSync(componentVuePath, 'utf-8');
-      }
-      if (componentReactPath) {
-        reactFiles[playgroundConfig.entryName?.react || 'App.tsx'] =
-          fs.readFileSync(componentReactPath, 'utf-8');
-      }
-
-      const finalHtmlFiles = {
-        ...globalFiles,
-        ...htmlFiles,
-        ...scopeFiles,
-      };
-      const finalVueFiles = {
-        ...globalFiles,
-        ...vueFiles,
-        ...scopeFiles,
-      };
-      const finalReactFiles = {
-        ...globalFiles,
-        ...reactFiles,
-        ...scopeFiles,
-      };
-
-      const getUrl =
-        typeof playgroundConfig.url === 'function'
-          ? playgroundConfig.url
-          : (content: string) => `${playgroundConfig.url}#${content}`;
-
-      const convert =
-        playgroundConfig.fn ||
-        ((files: Record<string, string>) => utoa(JSON.stringify(files)));
-      const htmlBase64Content = convert(finalHtmlFiles);
-      const vueBase64Content = convert(finalVueFiles);
-      const reactBase64Content = convert(finalReactFiles);
-      htmlPlayground = getUrl(htmlBase64Content);
-      vuePlayground = getUrl(vueBase64Content);
-      reactPlayground = getUrl(reactBase64Content);
-    } catch (error) {
-      console.warn('[vitepress-demo-plugin] Get playground url error:', error);
-    }
-  })();
+  const {
+    html: htmlPlayground,
+    vue: vuePlayground,
+    react: reactPlayground,
+  } = createPlaygroundUrls({
+    playground,
+    playgroundName: attributes.playground,
+    scope: scopeValue,
+    files,
+    inputFiles,
+    componentPaths,
+    baseDir: dirPath,
+  });
 
   const sourceCode = `
   ${

--- a/packages/plugin/src/markdown/utils/attributes.ts
+++ b/packages/plugin/src/markdown/utils/attributes.ts
@@ -1,0 +1,49 @@
+const attributeRegex = {
+  title: /title="(.*?)"/,
+  vuePath: /vue="(.*?)"/,
+  htmlPath: /html="(.*?)"/,
+  reactPath: /react="(.*?)"/,
+  description: /description="(.*?)"/,
+  order: /order="(.*?)"/,
+  select: /select="(.*?)"/,
+  github: /github="(.*?)"/,
+  gitlab: /gitlab="(.*?)"/,
+  stackblitz: /stackblitz="(.*?)"/,
+  codesandbox: /codesandbox="(.*?)"/,
+  scope: /scope="(.*?)"/,
+  vueFiles: /vueFiles=("\{((.|\n)*?)\}"|"\[((.|\n)*?)\]")/,
+  reactFiles: /reactFiles=("\{((.|\n)*?)\}"|"\[((.|\n)*?)\]")/,
+  htmlFiles: /htmlFiles=("\{((.|\n)*?)\}"|"\[((.|\n)*?)\]")/,
+  ssg: /ssg="(.*?)"/,
+  htmlWriteWay: /htmlWriteWay="(.*?)"/,
+  background: /background="(.*?)"/,
+  playground: /playground="(.*?)"/,
+};
+
+const getAttribute = (content: string, regex: RegExp) =>
+  content.match(regex)?.[1];
+
+export const parsePreviewAttributes = (content: string) => ({
+  title: getAttribute(content, attributeRegex.title) || '',
+  vuePath: getAttribute(content, attributeRegex.vuePath),
+  htmlPath: getAttribute(content, attributeRegex.htmlPath),
+  reactPath: getAttribute(content, attributeRegex.reactPath),
+  description: getAttribute(content, attributeRegex.description) || '',
+  order: getAttribute(content, attributeRegex.order),
+  select: getAttribute(content, attributeRegex.select),
+  github: getAttribute(content, attributeRegex.github) || '',
+  gitlab: getAttribute(content, attributeRegex.gitlab) || '',
+  stackblitz: getAttribute(content, attributeRegex.stackblitz),
+  codesandbox: getAttribute(content, attributeRegex.codesandbox),
+  scope: getAttribute(content, attributeRegex.scope) || '',
+  vueFiles: getAttribute(content, attributeRegex.vueFiles),
+  reactFiles: getAttribute(content, attributeRegex.reactFiles),
+  htmlFiles: getAttribute(content, attributeRegex.htmlFiles),
+  ssg: !!getAttribute(content, attributeRegex.ssg),
+  htmlWriteWay:
+    getAttribute(content, attributeRegex.htmlWriteWay) || 'write',
+  background: getAttribute(content, attributeRegex.background),
+  playground: getAttribute(content, attributeRegex.playground),
+});
+
+export type PreviewAttributes = ReturnType<typeof parsePreviewAttributes>;

--- a/packages/plugin/src/markdown/utils/component.ts
+++ b/packages/plugin/src/markdown/utils/component.ts
@@ -1,9 +1,4 @@
-// <demo></demo> or <demo />
-export const demoReg = [
-  /<demo(\s|\n)((.|\n)*)><\/demo>/,
-  /<demo(\s|\n)((.|\n)*)\/>/,
-];
-
+/* eslint-disable no-param-reassign */
 const htmlCommentReg = /<!--[\s\S]*?-->/g;
 const scriptSetupOpenTagReg =
   /<\s*script\b(?=[^>]*\ssetup(?:[\s=>/]|>))[^>]*>/i;
@@ -25,7 +20,7 @@ const hasScriptSetupOpenTag = (content?: string) =>
   !!content && scriptSetupOpenTagReg.test(stripHtmlComments(content));
 
 const findPendingScriptSetupToken = (
-  tokens: MarkdownToken[]
+  tokens: MarkdownToken[],
 ): MarkdownToken | null => {
   for (const token of tokens) {
     if (token?.type === 'html_block' && hasScriptSetupOpenTag(token.content)) {
@@ -45,13 +40,13 @@ const findPendingScriptSetupToken = (
 const includesInjectedCode = (
   content: string,
   path: string,
-  componentName?: string
+  componentName?: string,
 ) => content.includes(path) && (!componentName || content.includes(componentName));
 
 const injectIntoScriptSetupContent = (content: string, importCode: string) =>
   content.replace(
     scriptSetupOpenTagReg,
-    (tagOpen) => `${tagOpen}\n${importCode}`
+    (tagOpen) => `${tagOpen}\n${importCode}`,
   );
 
 export const prepareScriptSetupToken = (env: any, tokens: any[]) => {
@@ -64,26 +59,26 @@ export const prepareScriptSetupToken = (env: any, tokens: any[]) => {
 
 /**
  * 注入 script 脚本
- * @param mdInstance
+ * @param env
  * @param path
- * @param componentName
+ * @param name
  */
 export const injectComponentImportScript = (
   env: any,
   path: string,
   name?: string,
-  type?: 'dynamicImport' | 'inject'
+  type?: 'dynamicImport' | 'inject',
 ) => {
   const scriptsCode = env.sfcBlocks.scripts as any[];
 
   // 判断MD文件内部是否本身就存在 <script setup> 脚本
   const scriptSetupBlock = hasScriptSetupOpenTag(
-    env.sfcBlocks.scriptSetup?.tagOpen
+    env.sfcBlocks.scriptSetup?.tagOpen,
   )
     ? env.sfcBlocks.scriptSetup
     : scriptsCode.find((script: any) => hasScriptSetupOpenTag(script.tagOpen));
   const pendingScriptSetupToken = hasScriptSetupOpenTag(
-    env[pendingScriptSetupTokenKey]?.content
+    env[pendingScriptSetupTokenKey]?.content,
   )
     ? env[pendingScriptSetupTokenKey]
     : null;
@@ -123,7 +118,7 @@ export const injectComponentImportScript = (
 
     scriptSetupBlock.content = injectIntoScriptSetupContent(
       scriptSetupBlock.content,
-      importCode
+      importCode,
     );
     scriptSetupBlock.contentStripped = `${importCode}\n${
       scriptSetupBlock.contentStripped || ''
@@ -141,7 +136,7 @@ export const injectComponentImportScript = (
 
     pendingScriptSetupToken.content = injectIntoScriptSetupContent(
       pendingScriptSetupToken.content,
-      importCode
+      importCode,
     );
     return;
   }
@@ -184,8 +179,8 @@ export const composeComponentName = (path: string) => {
     'Temp' +
     btoa(
       encodeURIComponent(
-        componentList.join('-').split('.').slice(0, -1).join('.')
-      )
+        componentList.join('-').split('.').slice(0, -1).join('.'),
+      ),
     ).replace(/=/g, 'Equal')
   );
 };

--- a/packages/plugin/src/markdown/utils/demo.ts
+++ b/packages/plugin/src/markdown/utils/demo.ts
@@ -1,0 +1,5 @@
+// <demo></demo> or <demo />
+export const demoReg = [
+  /<demo(\s|\n)((.|\n)*)><\/demo>/,
+  /<demo(\s|\n)((.|\n)*)\/>/,
+];

--- a/packages/plugin/src/markdown/utils/files.ts
+++ b/packages/plugin/src/markdown/utils/files.ts
@@ -1,0 +1,73 @@
+import fs from 'fs';
+import path from 'path';
+import { PreviewFiles } from './types';
+
+type ComponentPaths = Record<keyof PreviewFiles, string>;
+type InputFiles = Record<keyof PreviewFiles, string | undefined>;
+
+export const getRelativePath = (from: string, to: string) =>
+  path.relative(from, to).replace(/\\/g, '/');
+
+export const getAbsolutePath = (baseDir: string, filePath?: string) =>
+  path.resolve(baseDir, filePath || '.').replace(/\\/g, '/');
+
+const formatFilesAttribute = (value: string) =>
+  value
+    .replace(/'/g, '"')
+    .replace(/\\n/g, '')
+    .trim()
+    .replace(/^"/, '')
+    .replace(/"$/, '')
+    .replace(/,(\s|\n)*\}$/, '}')
+    .replace(/,(\s|\n)*\]$/, ']');
+
+export const readPreviewFiles = (
+  inputFiles: InputFiles,
+  componentPaths: ComponentPaths,
+  baseDir: string,
+): PreviewFiles => {
+  const files: PreviewFiles = {
+    vue: {},
+    react: {},
+    html: {},
+  };
+
+  for (const type of Object.keys(inputFiles) as (keyof PreviewFiles)[]) {
+    const value = formatFilesAttribute(inputFiles[type] || '');
+    if (!value) {
+      continue;
+    }
+
+    try {
+      const codeFiles = JSON.parse(value);
+      if (Array.isArray(codeFiles)) {
+        (codeFiles as string[]).forEach((file) => {
+          const filePath = getAbsolutePath(baseDir, file);
+          const fileName = getRelativePath(
+            path.dirname(componentPaths[type]),
+            filePath,
+          );
+          files[type][fileName] = { filename: file, code: '' };
+        });
+      } else if (typeof codeFiles === 'object' && codeFiles) {
+        for (const file in codeFiles) {
+          files[type][file] = { filename: codeFiles[file], code: '' };
+        }
+      }
+
+      for (const file in files[type]) {
+        const filename = files[type][file].filename;
+        const absolutePath = getAbsolutePath(baseDir, filename);
+        if (filename && fs.existsSync(absolutePath)) {
+          files[type][file].code = fs.readFileSync(absolutePath, 'utf-8');
+        } else {
+          delete files[type][file];
+        }
+      }
+    } catch (error) {
+      // 格式错误，则不展示该文件
+    }
+  }
+
+  return files;
+};

--- a/packages/plugin/src/markdown/utils/index.ts
+++ b/packages/plugin/src/markdown/utils/index.ts
@@ -1,0 +1,6 @@
+export * from './attributes';
+export * from './component';
+export * from './demo';
+export * from './files';
+export * from './playground';
+export * from './types';

--- a/packages/plugin/src/markdown/utils/playground.ts
+++ b/packages/plugin/src/markdown/utils/playground.ts
@@ -1,0 +1,124 @@
+import fs from 'fs';
+import path from 'path';
+import { getAbsolutePath, getRelativePath } from './files';
+import { Playground, PreviewFiles } from './types';
+
+type ComponentPaths = Record<keyof PreviewFiles, string>;
+
+export interface PlaygroundUrls {
+  html: string;
+  vue: string;
+  react: string;
+}
+
+interface CreatePlaygroundUrlsOptions {
+  playground: Playground;
+  playgroundName?: string;
+  scope: string;
+  files: PreviewFiles;
+  inputFiles: Record<keyof PreviewFiles, string | undefined>;
+  componentPaths: ComponentPaths;
+  baseDir: string;
+}
+
+const emptyPlaygroundUrls = (): PlaygroundUrls => ({
+  html: '',
+  vue: '',
+  react: '',
+});
+
+const encodeFiles = (files: Record<string, string>) =>
+  btoa(unescape(encodeURIComponent(JSON.stringify(files))));
+
+const appendPreviewFiles = (
+  target: Record<string, string>,
+  files: PreviewFiles[keyof PreviewFiles],
+  componentPath: string,
+  baseDir: string,
+) => {
+  Object.values(files).forEach((item) => {
+    const filePath = getAbsolutePath(baseDir, item.filename);
+    if (filePath === componentPath) {
+      return;
+    }
+    const filename = getRelativePath(path.dirname(componentPath), filePath);
+    target[filename] = item.code;
+  });
+};
+
+export const createPlaygroundUrls = ({
+  playground,
+  playgroundName,
+  scope,
+  files,
+  inputFiles,
+  componentPaths,
+  baseDir,
+}: CreatePlaygroundUrlsOptions): PlaygroundUrls => {
+  const urls = emptyPlaygroundUrls();
+  if (!playground.show) {
+    return urls;
+  }
+
+  try {
+    const templates = playground.templates || [];
+    const globalFiles = templates.find((item) => item.scope === 'global')?.files;
+    const scopeFiles = templates.find((item) => item.scope === scope)?.files;
+    const platformFiles = {
+      html: { ...templates.find((item) => item.scope === 'html')?.files },
+      vue: { ...templates.find((item) => item.scope === 'vue')?.files },
+      react: { ...templates.find((item) => item.scope === 'react')?.files },
+    };
+
+    (Object.keys(platformFiles) as (keyof PreviewFiles)[]).forEach((type) => {
+      if (inputFiles[type]) {
+        appendPreviewFiles(
+          platformFiles[type],
+          files[type],
+          componentPaths[type],
+          baseDir,
+        );
+      }
+    });
+
+    const config = Array.isArray(playground.config)
+      ? playground.config.find((item) => item.name === playgroundName)
+      : playground.config;
+    if (!config?.url) {
+      return urls;
+    }
+
+    const entryNames: Record<keyof PreviewFiles, string> = {
+      html: config.entryName?.html || 'index.html',
+      vue: config.entryName?.vue || 'App.vue',
+      react: config.entryName?.react || 'App.tsx',
+    };
+    (Object.keys(componentPaths) as (keyof PreviewFiles)[]).forEach((type) => {
+      if (componentPaths[type]) {
+        platformFiles[type][entryNames[type]] = fs.readFileSync(
+          componentPaths[type],
+          'utf-8',
+        );
+      }
+    });
+
+    const getUrl =
+      typeof config.url === 'function'
+        ? config.url
+        : (content: string) => `${config.url}#${content}`;
+    const convert = config.fn || encodeFiles;
+
+    (Object.keys(platformFiles) as (keyof PreviewFiles)[]).forEach((type) => {
+      const finalFiles = {
+        ...globalFiles,
+        ...platformFiles[type],
+        ...scopeFiles,
+      };
+      urls[type] = getUrl(convert(finalFiles));
+    });
+  } catch (error) {
+    console.warn('[vitepress-demo-plugin] Get playground url error:', error);
+  }
+
+  return urls;
+};

--- a/packages/plugin/src/markdown/utils/types.ts
+++ b/packages/plugin/src/markdown/utils/types.ts
@@ -1,0 +1,118 @@
+import { PlatformTemplate } from '../../constant/type';
+import { Locale } from '@/locales/text';
+
+export interface DefaultProps {
+  title?: string;
+  description?: string;
+  vue?: string;
+  html?: string;
+  react?: string;
+}
+
+export interface TabConfig {
+  /**
+   * @cn 代码切换 tab 的展示顺序
+   * @en The order of the code switch tab
+   */
+  order?: string;
+  /**
+   * @cn 是否显示 tab
+   * @en Whether to show the tab
+   */
+  visible?: boolean;
+  /**
+   * @cn 默认选中的 tab
+   * @en The default selected tab
+   */
+  select?: string;
+}
+
+export type Files = Record<string, { code: string; filename: string }>;
+
+export type PreviewFiles = Record<'vue' | 'react' | 'html', Files>;
+
+export type Platform = {
+  show: boolean;
+  templates?: PlatformTemplate[];
+};
+
+export type CodeFiles = string[] | Record<string, string>;
+
+export type PlaygroundConfig = {
+  url: string | ((content: string) => string);
+  fn?: (files: Record<string, string>) => string;
+  entryName?: {
+    vue?: string;
+    react?: string;
+    html?: string;
+  };
+};
+
+export type Playground = {
+  show: boolean;
+  templates?: PlatformTemplate[];
+  config: PlaygroundConfig | (PlaygroundConfig & { name: string })[];
+};
+
+export interface VitepressDemoBoxConfig {
+  /**
+   * @cn demo所在目录
+   * @en The directory of the demo
+   */
+  demoDir?: string;
+  /**
+   * @cn 代码切换 tab 的配置
+   * @en The configuration of the code switch tab
+   */
+  tab?: TabConfig;
+  /**
+   * @cn stackblitz 平台配置
+   * @en The configuration of the stackblitz platform
+   */
+  stackblitz?: Platform;
+  /**
+   * @cn codesandbox 平台配置
+   * @en The configuration of the codesandbox platform
+   */
+  codesandbox?: Platform;
+  /**
+   * @cn vue 展示的代码文件
+   * @en The code files of the vue
+   */
+  vueFiles?: CodeFiles;
+  /**
+   * @cn react 展示的代码文件
+   * @en The code files of the react
+   */
+  reactFiles?: CodeFiles;
+  /**
+   * @cn html 展示的代码文件
+   * @en The code files of the html
+   */
+  htmlFiles?: CodeFiles;
+  /**
+   * @cn 亮色模式主题，参考 https://shiki.style/themes#bundled-themes
+   * @en The light theme, reference https://shiki.style/themes#bundled-themes
+   */
+  lightTheme?: string;
+  /**
+   * @cn 暗色模式主题，参考 https://shiki.style/themes#bundled-themes
+   * @en The dark theme, reference https://shiki.style/themes#bundled-themes
+   */
+  darkTheme?: string;
+  /**
+   * @cn 亮色/暗色模式统一的主题(建议使用 lightTheme 和 darkTheme 分开)，参考 https://shiki.style/themes#bundled-themes
+   * @en The light/dark theme, reference https://shiki.style/themes#bundled-themes
+   */
+  theme?: string;
+  /**
+   * @cn 国际化配置 'zh-CN' | 'en-US'
+   * @en The locale configuration 'zh-CN' | 'en-US'
+   */
+  locale?: Locale;
+  /**
+   * @cn 自定义 playground 平台配置
+   * @en The configuration of the custom playground platform
+   */
+  playground?: Playground;
+}


### PR DESCRIPTION
## Summary

- extract demo attribute parsing and multi-file loading from `preview.ts`
- isolate playground URL generation and template merging in a dedicated utility
- split the original markdown utilities into focused modules while preserving existing type exports and the `./utils` entry point

## Testing

- `pnpm --dir packages/plugin build`
- `pnpm build:docs`
- `git diff --check origin/main...HEAD`