### PR TITLE
fix: include source files in online playgrounds

### DIFF
--- a/packages/docs/.vitepress/config.mts
+++ b/packages/docs/.vitepress/config.mts
@@ -18,10 +18,10 @@ function fileURLToPath(fileURL: string) {
 
 const srcMain = `
 import { createApp } from "vue";
-import Demo from "./Demo.vue";
+import App from "./App.vue";
 import 'element-plus/dist/index.css'
 
-const app = createApp(Demo);
+const app = createApp(App);
 app.mount("#app");`.trim();
 
 const indexHtml = `

--- a/packages/docs/en/guide/preset.md
+++ b/packages/docs/en/guide/preset.md
@@ -47,15 +47,15 @@ export default defineConfig({
 ::: details Expand to view the stackblitz platform Vue preset files and codes
 ::: code-group
 
-```html [src/Demo.vue]
+```html [src/App.vue]
 <!-- Will be dynamically replaced with your demo code -->
 ```
 
 ```ts [src/main.ts]
 import { createApp } from "vue";
-import Demo from "./Demo.vue";
+import App from "./App.vue";
 
-const app = createApp(Demo);
+const app = createApp(App);
 app.mount("#app");
 ```
 
@@ -141,17 +141,17 @@ export default defineConfig({
 ::: details Expand to view the stackblitz platform React preset files and code
 ::: code-group
 
-```html [src/Demo.tsx]
+```html [src/App.tsx]
 <!-- Will be dynamically replaced with your demo code -->
 ```
 
 ```ts [src/main.tsx]
 import React from "react";
 import { createRoot } from "react-dom/client";
-import Demo from "./Demo.tsx";
+import App from "./App.tsx";
 
 const root = createRoot(document.querySelector("#app"));
-root.render(<Demo />);
+root.render(<App />);
 ```
 
 ```json [.stackblitzrc]
@@ -248,15 +248,15 @@ export default defineConfig({
 ::: details Expand to view codesandbox platform Vue preset files and codes
 ::: code-group
 
-```html [Demo.vue]
+```html [App.vue]
 <!-- Expand to view codesandbox platform Vue preset files and codes -->
 ```
 
 ```ts [main.ts]
 import { createApp } from "vue";
-import Demo from "./Demo.vue";
+import App from "./App.vue";
 
-const app = createApp(Demo);
+const app = createApp(App);
 app.mount("#app");
 ```
 
@@ -317,17 +317,17 @@ app.mount("#app");
 ::: details Expand to view the codesandbox platform React preset files and codes
 ::: code-group
 
-```html [Demo.tsx]
+```html [App.tsx]
 <!-- Expand to view the stackblitz platform Html preset files and codes -->
 ```
 
 ```ts [main.tsx]
 import React from "react";
 import { createRoot } from "react-dom/client";
-import Demo from "./Demo.tsx";
+import App from "./App.tsx";
 
 const root = createRoot(document.querySelector("#app"));
-root.render(<Demo />);
+root.render(<App />);
 ```
 
 ```html [index.html]
@@ -475,7 +475,7 @@ export default defineConfig({
               scope: 'vue', // Only valid for Vue demo components // [!code ++]
               files: { // [!code ++]
                 // Replace the default main.ts file // [!code ++]
-                'main.ts': `import { createApp } from "vue";\nimport Demo from "./Demo.vue";\nconst app = createApp(Demo);\napp.mount("#app");`, // [!code ++]
+                'main.ts': `import { createApp } from "vue";\nimport App from "./App.vue";\nconst app = createApp(App);\napp.mount("#app");`, // [!code ++]
               } // [!code ++]
             }, // [!code ++]
           ]
@@ -515,7 +515,7 @@ export default defineConfig({
               scope: 'vue', // Only valid for Vue demo components
               files: { 
                 // Replace the default main.ts file
-                'main.ts': `import { createApp } from "vue";\nimport Demo from "./Demo.vue";\nconst app = createApp(Demo);\napp.mount("#app");`, 
+                'main.ts': `import { createApp } from "vue";\nimport App from "./App.vue";\nconst app = createApp(App);\napp.mount("#app");`,
               } 
             },
             { // [!code ++]
@@ -821,6 +821,7 @@ You can now open each demo in a different playground:
 <demo
   vue="../demos/multiple.vue"
   :vueFiles="['../demos/multiple.vue', '../demos/constant/students.ts']" playground="codeplayer"
+  scope="codeplayer"
 />
 ```
 

--- a/packages/docs/guide/preset.md
+++ b/packages/docs/guide/preset.md
@@ -47,15 +47,15 @@ export default defineConfig({
 ::: details 展开查看 stackblitz 平台 Vue 预设文件及代码
 ::: code-group
 
-```html [src/Demo.vue]
+```html [src/App.vue]
 <!-- 会动态替换为你的 demo 代码 -->
 ```
 
 ```ts [src/main.ts]
 import { createApp } from "vue";
-import Demo from "./Demo.vue";
+import App from "./App.vue";
 
-const app = createApp(Demo);
+const app = createApp(App);
 app.mount("#app");
 ```
 
@@ -141,17 +141,17 @@ export default defineConfig({
 ::: details 展开查看 stackblitz 平台 React 预设文件及代码
 ::: code-group
 
-```html [src/Demo.tsx]
+```html [src/App.tsx]
 <!-- 会动态替换为你的 demo 代码 -->
 ```
 
 ```ts [src/main.tsx]
 import React from "react";
 import { createRoot } from "react-dom/client";
-import Demo from "./Demo.tsx";
+import App from "./App.tsx";
 
 const root = createRoot(document.querySelector("#app"));
-root.render(<Demo />);
+root.render(<App />);
 ```
 
 ```json [.stackblitzrc]
@@ -248,15 +248,15 @@ export default defineConfig({
 ::: details 展开查看 codesandbox 平台 Vue 预设文件及代码
 ::: code-group
 
-```html [Demo.vue]
+```html [App.vue]
 <!-- 会动态替换为你的 demo 代码 -->
 ```
 
 ```ts [main.ts]
 import { createApp } from "vue";
-import Demo from "./Demo.vue";
+import App from "./App.vue";
 
-const app = createApp(Demo);
+const app = createApp(App);
 app.mount("#app");
 ```
 
@@ -317,17 +317,17 @@ app.mount("#app");
 ::: details 展开查看 codesandbox 平台 React 预设文件及代码
 ::: code-group
 
-```html [Demo.tsx]
+```html [App.tsx]
 <!-- 会动态替换为你的 demo 代码 -->
 ```
 
 ```ts [main.tsx]
 import React from "react";
 import { createRoot } from "react-dom/client";
-import Demo from "./Demo.tsx";
+import App from "./App.tsx";
 
 const root = createRoot(document.querySelector("#app"));
-root.render(<Demo />);
+root.render(<App />);
 ```
 
 ```html [index.html]
@@ -475,7 +475,7 @@ export default defineConfig({
               scope: 'vue', // 仅针对 Vue 类型的 demo 组件生效 // [!code ++]
               files: { // [!code ++]
                 // 替换预设的 main.ts 文件 // [!code ++]
-                'src/main.ts': `import { createApp } from "vue";\nimport Demo from "./Demo.vue";\nconst app = createApp(Demo);\napp.mount("#app");`, // [!code ++]
+                'src/main.ts': `import { createApp } from "vue";\nimport App from "./App.vue";\nconst app = createApp(App);\napp.mount("#app");`, // [!code ++]
               } // [!code ++]
             }, // [!code ++]
           ]
@@ -515,7 +515,7 @@ export default defineConfig({
               scope: 'vue', // 仅针对 Vue 类型的 demo 组件生效
               files: { 
                 // 替换预设的 main.ts 文件
-                'src/main.ts': `import { createApp } from "vue";\nimport Demo from "./Demo.vue";\nconst app = createApp(Demo);\napp.mount("#app");`, 
+                'src/main.ts': `import { createApp } from "vue";\nimport App from "./App.vue";\nconst app = createApp(App);\napp.mount("#app");`,
               } 
             },
             { // [!code ++]
@@ -817,6 +817,7 @@ export default defineConfig({
 <demo
   vue="../demos/multiple.vue"
   :vueFiles="['../demos/multiple.vue', '../demos/constant/students.ts']" playground="codeplayer"
+  scope="codeplayer"
 />
 ```
 

--- a/packages/plugin/src/components/icons/codesandbox.vue
+++ b/packages/plugin/src/components/icons/codesandbox.vue
@@ -47,6 +47,7 @@ import {
   DEFAULT_DESCRIPTION,
   DEFAULT_TITLE,
   PlatformTemplate,
+  PreviewFile,
 } from '@/constant/type';
 
 const props = defineProps<{
@@ -56,6 +57,7 @@ const props = defineProps<{
   description?: string;
   scope?: string;
   templates: PlatformTemplate[];
+  files: Record<string, PreviewFile>;
 }>();
 
 const parameters = computed(() =>
@@ -66,6 +68,7 @@ const parameters = computed(() =>
     description: props.description || DEFAULT_DESCRIPTION,
     scope: props.scope,
     templates: props.templates,
+    files: props.files,
   })
 );
 

--- a/packages/plugin/src/components/icons/stackblitz.vue
+++ b/packages/plugin/src/components/icons/stackblitz.vue
@@ -22,6 +22,7 @@ import {
   DEFAULT_DESCRIPTION,
   DEFAULT_TITLE,
   PlatformTemplate,
+  PreviewFile,
 } from '@/constant/type';
 
 const props = defineProps<{
@@ -31,6 +32,7 @@ const props = defineProps<{
   description?: string;
   templates: PlatformTemplate[];
   scope?: string;
+  files: Record<string, PreviewFile>;
 }>();
 
 function open() {
@@ -41,6 +43,7 @@ function open() {
     description: props.description || DEFAULT_DESCRIPTION,
     templates: props.templates || [],
     scope: props.scope,
+    files: props.files,
   });
 }
 </script>

--- a/packages/plugin/src/components/index.vue
+++ b/packages/plugin/src/components/index.vue
@@ -140,6 +140,10 @@ const currentCode = computed(() => {
   return props[`${type.value}Code` as keyof VitepressDemoBoxProps];
 });
 
+const demoCode = computed(() => {
+  return props[`${type.value}Code` as keyof VitepressDemoBoxProps] as string;
+});
+
 const displayCode = ref('');
 watchEffect(async () => {
   await updatetDisplayCode();
@@ -427,18 +431,20 @@ watch(
       <div :class="[ns.bem('description', 'handle-btn')]">
         <Tooltip :content="i18n.openInStackblitz" v-if="stackblitz.show">
           <StackblitzIcon
-            :code="currentCode"
+            :code="demoCode"
             :type="type"
             :scope="scope || ''"
             :templates="stackblitz.templates || []"
+            :files="currentFiles"
           />
         </Tooltip>
         <Tooltip :content="i18n.openInCodeSandbox" v-if="codesandbox.show">
           <CodeSandboxIcon
-            :code="currentCode"
+            :code="demoCode"
             :type="type"
             :scope="scope || ''"
             :templates="codesandbox.templates || []"
+            :files="currentFiles"
           />
         </Tooltip>
         <Tooltip

--- a/packages/plugin/src/components/platform/index.ts
+++ b/packages/plugin/src/components/platform/index.ts
@@ -1,9 +1,38 @@
+import { ComponentType, PlatformParams } from '@/constant/type';
+
 export function getInitialFile(type: string) {
   if (type === 'vue') {
-    return '/src/Demo.vue';
+    return '/src/App.vue';
   }
   if (type === 'react') {
-    return '/src/Demo.tsx';
+    return '/src/App.tsx';
   }
   return 'index.html';
+}
+
+export function getSourceFiles(params: PlatformParams) {
+  const baseDir = params.type === ComponentType.HTML ? '' : 'src/';
+
+  return Object.fromEntries(
+    Object.entries(params.files || {})
+      .filter(([, file]) => !file.entry)
+      .map(([filename, file]) => [
+        normalizePath(`${baseDir}${file.path || filename}`),
+        file.code,
+      ]),
+  );
+}
+
+function normalizePath(filename: string) {
+  return filename
+    .split('/')
+    .reduce<string[]>((parts, part) => {
+      if (part === '..') {
+        parts.pop();
+      } else if (part && part !== '.') {
+        parts.push(part);
+      }
+      return parts;
+    }, [])
+    .join('/');
 }

--- a/packages/plugin/src/components/platform/sandbox/files.ts
+++ b/packages/plugin/src/components/platform/sandbox/files.ts
@@ -1,0 +1,10 @@
+export function toCodeSandboxFiles(
+  files?: Record<string, string> | Record<string, { content: string }>,
+) {
+  return Object.fromEntries(
+    Object.entries(files || {}).map(([filename, file]) => [
+      filename,
+      typeof file === 'string' ? { content: file || '' } : file,
+    ]),
+  );
+}

--- a/packages/plugin/src/components/platform/sandbox/html.ts
+++ b/packages/plugin/src/components/platform/sandbox/html.ts
@@ -2,15 +2,17 @@
 import { getParameters } from 'codesandbox/lib/api/define';
 import { genHtmlTemplate } from '../templates';
 import { PlatformParams } from '@/constant/type';
+import { toCodeSandboxFiles } from './files';
 
 export function getHtmlCodeSandboxParams(params: PlatformParams) {
   const { code } = params;
   return (getParameters as any)({
     files: {
+      ...toCodeSandboxFiles(params.sourceFiles),
       'index.html': {
         content: genHtmlTemplate({ code }),
       },
-      ...params.customFiles,
+      ...toCodeSandboxFiles(params.customFiles),
     },
     template: 'static',
   });

--- a/packages/plugin/src/components/platform/sandbox/index.ts
+++ b/packages/plugin/src/components/platform/sandbox/index.ts
@@ -2,6 +2,7 @@ import { ComponentType, PlatformParams } from '@/constant/type';
 import { getVueCodeSandboxParams } from './vue';
 import { getReactCodeSandboxParams } from './react';
 import { getHtmlCodeSandboxParams } from './html';
+import { getSourceFiles } from '..';
 
 export function getCodeSandboxParams(params: PlatformParams) {
   const globalFiles = (params.templates || []).find(
@@ -14,6 +15,7 @@ export function getCodeSandboxParams(params: PlatformParams) {
     (item) => item.scope === params.scope
   )?.files;
   params.customFiles = {
+    ...getSourceFiles(params),
     ...globalFiles,
     ...typeFiles,
     ...scopeFiles,

--- a/packages/plugin/src/components/platform/sandbox/index.ts
+++ b/packages/plugin/src/components/platform/sandbox/index.ts
@@ -14,26 +14,23 @@ export function getCodeSandboxParams(params: PlatformParams) {
   const scopeFiles = (params.templates || []).find(
     (item) => item.scope === params.scope
   )?.files;
-  params.customFiles = {
-    ...getSourceFiles(params),
-    ...globalFiles,
-    ...typeFiles,
-    ...scopeFiles,
+  const platformParams = {
+    ...params,
+    sourceFiles: getSourceFiles(params),
+    customFiles: {
+      ...globalFiles,
+      ...typeFiles,
+      ...scopeFiles,
+    },
   };
-  for (let file in params.customFiles) {
-    // @ts-ignore
-    params.customFiles[file] = {
-      content: params.customFiles[file] || '',
-    };
-  }
 
   if (params.type === ComponentType.VUE) {
-    return getVueCodeSandboxParams(params);
+    return getVueCodeSandboxParams(platformParams);
   }
   if (params.type === ComponentType.REACT) {
-    return getReactCodeSandboxParams(params);
+    return getReactCodeSandboxParams(platformParams);
   }
   if (params.type === ComponentType.HTML) {
-    return getHtmlCodeSandboxParams(params);
+    return getHtmlCodeSandboxParams(platformParams);
   }
 }

--- a/packages/plugin/src/components/platform/sandbox/react.ts
+++ b/packages/plugin/src/components/platform/sandbox/react.ts
@@ -28,7 +28,7 @@ export function getReactCodeSandboxParams(params: PlatformParams) {
       'src/main.tsx': {
         content: genMainTs(ComponentType.REACT),
       },
-      'src/Demo.tsx': {
+      'src/App.tsx': {
         content: code,
       },
       ...params.customFiles,

--- a/packages/plugin/src/components/platform/sandbox/react.ts
+++ b/packages/plugin/src/components/platform/sandbox/react.ts
@@ -7,16 +7,19 @@ import {
   genMainTs,
   genPackageJson,
 } from '../templates';
+import { toCodeSandboxFiles } from './files';
 
 export function getReactCodeSandboxParams(params: PlatformParams) {
   const { code } = params;
+  const sourceCodes = Object.values(params.sourceFiles || {});
   return (getParameters as any)({
     files: {
+      ...toCodeSandboxFiles(params.sourceFiles),
       'package.json': {
         content: genPackageJson({
           type: ComponentType.REACT,
           platform: PlatformType.CODESANDBOX,
-          code,
+          codes: [code, ...sourceCodes],
         }),
       },
       'tsconfig.json': {
@@ -31,7 +34,7 @@ export function getReactCodeSandboxParams(params: PlatformParams) {
       'src/App.tsx': {
         content: code,
       },
-      ...params.customFiles,
+      ...toCodeSandboxFiles(params.customFiles),
     },
   });
 }

--- a/packages/plugin/src/components/platform/sandbox/vue.ts
+++ b/packages/plugin/src/components/platform/sandbox/vue.ts
@@ -7,16 +7,19 @@ import {
   genMainTs,
   genPackageJson,
 } from '../templates';
+import { toCodeSandboxFiles } from './files';
 
 export function getVueCodeSandboxParams(params: PlatformParams) {
   const { code } = params;
+  const sourceCodes = Object.values(params.sourceFiles || {});
   return (getParameters as any)({
     files: {
+      ...toCodeSandboxFiles(params.sourceFiles),
       'package.json': {
         content: genPackageJson({
           type: ComponentType.VUE,
           platform: PlatformType.CODESANDBOX,
-          code,
+          codes: [code, ...sourceCodes],
         }),
       },
       'tsconfig.json': {
@@ -31,7 +34,7 @@ export function getVueCodeSandboxParams(params: PlatformParams) {
       'src/App.vue': {
         content: code,
       },
-      ...params.customFiles,
+      ...toCodeSandboxFiles(params.customFiles),
     },
   });
 }

--- a/packages/plugin/src/components/platform/sandbox/vue.ts
+++ b/packages/plugin/src/components/platform/sandbox/vue.ts
@@ -28,7 +28,7 @@ export function getVueCodeSandboxParams(params: PlatformParams) {
       'src/main.ts': {
         content: genMainTs(ComponentType.VUE),
       },
-      'src/Demo.vue': {
+      'src/App.vue': {
         content: code,
       },
       ...params.customFiles,

--- a/packages/plugin/src/components/platform/stackblitz/html.ts
+++ b/packages/plugin/src/components/platform/stackblitz/html.ts
@@ -11,12 +11,13 @@ export const openHtmlStackblitz = (params: PlatformParams) => {
       description: description!,
       template: 'html',
       files: {
+        ...params.sourceFiles,
         'index.html': genHtmlTemplate({ code }),
         ...params.customFiles,
       },
     },
     {
       openFile: 'index.html',
-    }
+    },
   );
 };

--- a/packages/plugin/src/components/platform/stackblitz/index.ts
+++ b/packages/plugin/src/components/platform/stackblitz/index.ts
@@ -14,20 +14,23 @@ export function openStackblitz(params: PlatformParams) {
   const scopeFiles = (params.templates || []).find(
     (item) => item.scope === params.scope
   )?.files;
-  params.customFiles = {
-    ...getSourceFiles(params),
-    ...globalFiles,
-    ...typeFiles,
-    ...scopeFiles,
+  const platformParams = {
+    ...params,
+    sourceFiles: getSourceFiles(params),
+    customFiles: {
+      ...globalFiles,
+      ...typeFiles,
+      ...scopeFiles,
+    },
   };
 
   if (params.type === ComponentType.VUE) {
-    return openVueStackblitz(params);
+    return openVueStackblitz(platformParams);
   }
   if (params.type === ComponentType.REACT) {
-    return openReactStackblitz(params);
+    return openReactStackblitz(platformParams);
   }
   if (params.type === ComponentType.HTML) {
-    return openHtmlStackblitz(params);
+    return openHtmlStackblitz(platformParams);
   }
 }

--- a/packages/plugin/src/components/platform/stackblitz/index.ts
+++ b/packages/plugin/src/components/platform/stackblitz/index.ts
@@ -2,6 +2,7 @@ import { ComponentType, PlatformParams } from '@/constant/type';
 import { openHtmlStackblitz } from './html';
 import { openReactStackblitz } from './react';
 import { openVueStackblitz } from './vue';
+import { getSourceFiles } from '..';
 
 export function openStackblitz(params: PlatformParams) {
   const globalFiles = (params.templates || []).find(
@@ -14,6 +15,7 @@ export function openStackblitz(params: PlatformParams) {
     (item) => item.scope === params.scope
   )?.files;
   params.customFiles = {
+    ...getSourceFiles(params),
     ...globalFiles,
     ...typeFiles,
     ...scopeFiles,

--- a/packages/plugin/src/components/platform/stackblitz/react.ts
+++ b/packages/plugin/src/components/platform/stackblitz/react.ts
@@ -11,6 +11,7 @@ import {
 
 export const openReactStackblitz = (params: PlatformParams) => {
   const { code, title, description } = params;
+  const sourceCodes = Object.values(params.sourceFiles || {});
 
   stackblitz.openProject(
     {
@@ -18,13 +19,14 @@ export const openReactStackblitz = (params: PlatformParams) => {
       description: description!,
       template: 'node',
       files: {
+        ...params.sourceFiles,
         'src/App.tsx': code,
         'src/main.tsx': genMainTs(ComponentType.REACT),
         'index.html': genHtmlTemplate({ src: '/src/main.tsx' }),
         'package.json': genPackageJson({
           type: ComponentType.REACT,
           platform: PlatformType.STACKBLITZ,
-          code,
+          codes: [code, ...sourceCodes],
         }),
         'vite.config.js': genViteConfig(ComponentType.REACT),
         '.stackblitzrc': genStackblitzRc(),

--- a/packages/plugin/src/components/platform/stackblitz/react.ts
+++ b/packages/plugin/src/components/platform/stackblitz/react.ts
@@ -18,7 +18,7 @@ export const openReactStackblitz = (params: PlatformParams) => {
       description: description!,
       template: 'node',
       files: {
-        'src/Demo.tsx': code,
+        'src/App.tsx': code,
         'src/main.tsx': genMainTs(ComponentType.REACT),
         'index.html': genHtmlTemplate({ src: '/src/main.tsx' }),
         'package.json': genPackageJson({
@@ -33,7 +33,7 @@ export const openReactStackblitz = (params: PlatformParams) => {
       },
     },
     {
-      openFile: 'src/Demo.tsx',
-    }
+      openFile: 'src/App.tsx',
+    },
   );
 };

--- a/packages/plugin/src/components/platform/stackblitz/vue.ts
+++ b/packages/plugin/src/components/platform/stackblitz/vue.ts
@@ -18,7 +18,7 @@ export const openVueStackblitz = (params: PlatformParams) => {
       description: description!,
       template: 'node',
       files: {
-        'src/Demo.vue': code,
+        'src/App.vue': code,
         'src/main.ts': genMainTs(ComponentType.VUE),
         'index.html': genHtmlTemplate({ src: '/src/main.ts' }),
         'package.json': genPackageJson({
@@ -33,7 +33,7 @@ export const openVueStackblitz = (params: PlatformParams) => {
       },
     },
     {
-      openFile: 'src/Demo.vue',
-    }
+      openFile: 'src/App.vue',
+    },
   );
 };

--- a/packages/plugin/src/components/platform/stackblitz/vue.ts
+++ b/packages/plugin/src/components/platform/stackblitz/vue.ts
@@ -11,6 +11,7 @@ import {
 
 export const openVueStackblitz = (params: PlatformParams) => {
   const { code, title, description } = params;
+  const sourceCodes = Object.values(params.sourceFiles || {});
 
   stackblitz.openProject(
     {
@@ -18,13 +19,14 @@ export const openVueStackblitz = (params: PlatformParams) => {
       description: description!,
       template: 'node',
       files: {
+        ...params.sourceFiles,
         'src/App.vue': code,
         'src/main.ts': genMainTs(ComponentType.VUE),
         'index.html': genHtmlTemplate({ src: '/src/main.ts' }),
         'package.json': genPackageJson({
           type: ComponentType.VUE,
           platform: PlatformType.STACKBLITZ,
-          code,
+          codes: [code, ...sourceCodes],
         }),
         'vite.config.js': genViteConfig(ComponentType.VUE),
         '.stackblitzrc': genStackblitzRc(),

--- a/packages/plugin/src/components/platform/templates/main.ts
+++ b/packages/plugin/src/components/platform/templates/main.ts
@@ -1,18 +1,18 @@
 import { ComponentType } from '@/constant/type';
 
 const mainVue = `import { createApp } from "vue";
-import Demo from "./Demo.vue";
+import App from "./App.vue";
 
-const app = createApp(Demo);
+const app = createApp(App);
 app.mount("#app");
 `;
 
 const mainReact = `import React from "react";
 import { createRoot } from "react-dom/client";
-import Demo from "./Demo.tsx";
+import App from "./App.tsx";
 
 const root = createRoot(document.querySelector("#app"));
-root.render(<Demo />);
+root.render(<App />);
 `;
 
 export function genMainTs(type: ComponentType): string {

--- a/packages/plugin/src/components/platform/templates/package.ts
+++ b/packages/plugin/src/components/platform/templates/package.ts
@@ -4,7 +4,7 @@ import { ComponentType, PlatformType } from '@/constant/type';
 interface PackageJsonParams {
   type: ComponentType;
   platform: PlatformType;
-  code: string;
+  codes: string[];
   title?: string;
   description?: string;
 }
@@ -42,7 +42,7 @@ export const getDepsByType = (type: ComponentType, platform: PlatformType) => {
 };
 
 export function genPackageJson(params: PackageJsonParams): string {
-  const { type, platform, code, title, description } = params;
+  const { type, platform, codes, title, description } = params;
 
   const scripts =
     platform === PlatformType.STACKBLITZ
@@ -64,7 +64,7 @@ export function genPackageJson(params: PackageJsonParams): string {
     private: true,
     ...scripts,
     dependencies: {
-      ...getDeps(code),
+      ...getDeps(`${codes.join('\n')}\n`),
       ...dependencies,
     },
     devDependencies: {

--- a/packages/plugin/src/components/utils/deps.ts
+++ b/packages/plugin/src/components/utils/deps.ts
@@ -20,7 +20,9 @@ export function getDeps(code: string) {
       }
       return dep;
     })
-    .filter((dep) => dep !== '')
+    .filter(
+      (dep) => dep !== '' && !dep.startsWith('.') && !dep.startsWith('/'),
+    )
     .reduce((prevV: any, dep: string) => {
       prevV[dep] = 'latest';
       return prevV;

--- a/packages/plugin/src/constant/type.ts
+++ b/packages/plugin/src/constant/type.ts
@@ -22,7 +22,15 @@ export interface PlatformParams {
   platform?: PlatformType;
   templates?: PlatformTemplate[];
   scope?: string;
+  files?: Record<string, PreviewFile>;
   customFiles?: Record<string, string> | Record<string, { content: string }>;
+}
+
+export interface PreviewFile {
+  code: string;
+  filename: string;
+  entry?: boolean;
+  path?: string;
 }
 
 export const DEFAULT_TITLE = 'vitepress-demo';

--- a/packages/plugin/src/constant/type.ts
+++ b/packages/plugin/src/constant/type.ts
@@ -23,6 +23,7 @@ export interface PlatformParams {
   templates?: PlatformTemplate[];
   scope?: string;
   files?: Record<string, PreviewFile>;
+  sourceFiles?: Record<string, string>;
   customFiles?: Record<string, string> | Record<string, { content: string }>;
 }
 

--- a/packages/plugin/src/markdown/preview.ts
+++ b/packages/plugin/src/markdown/preview.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import MarkdownIt from 'markdown-it';
 import Token from 'markdown-it/lib/token';
 import path from 'path';
@@ -10,11 +9,7 @@ import {
   parsePreviewAttributes,
   readPreviewFiles,
 } from './utils';
-import type {
-  DefaultProps,
-  Playground,
-  VitepressDemoBoxConfig,
-} from './utils';
+import type { DefaultProps, Playground, VitepressDemoBoxConfig } from './utils';
 
 export type {
   CodeFiles,
@@ -44,9 +39,9 @@ export const transformPreview = (
   const {
     demoDir,
     tab = {},
-    stackblitz = { show: false },
-    codesandbox = { show: false },
-    playground = { show: false } as Playground,
+    stackblitz: globalStackblitz = { show: false },
+    codesandbox: globalCodesandbox = { show: false },
+    playground: globalPlayground = { show: false } as Playground,
   } = config || {};
   let {
     order = 'vue,react,html',
@@ -71,15 +66,24 @@ export const transformPreview = (
   if (attributes.select) {
     select = attributes.select;
   }
-  if (attributes.stackblitz) {
-    stackblitz.show = attributes.stackblitz === 'true';
-  }
-  if (attributes.codesandbox) {
-    codesandbox.show = attributes.codesandbox === 'true';
-  }
-  if (attributes.playground) {
-    playground.show = attributes.playground !== 'false';
-  }
+  const stackblitz = {
+    ...globalStackblitz,
+    show: attributes.stackblitz
+      ? attributes.stackblitz === 'true'
+      : globalStackblitz.show,
+  };
+  const codesandbox = {
+    ...globalCodesandbox,
+    show: attributes.codesandbox
+      ? attributes.codesandbox === 'true'
+      : globalCodesandbox.show,
+  };
+  const playground = {
+    ...globalPlayground,
+    show: attributes.playground
+      ? attributes.playground !== 'false'
+      : globalPlayground.show,
+  };
 
   const componentProps: DefaultProps = {
     title: attributes.title,

--- a/packages/plugin/src/markdown/utils/files.ts
+++ b/packages/plugin/src/markdown/utils/files.ts
@@ -60,6 +60,11 @@ export const readPreviewFiles = (
         const absolutePath = getAbsolutePath(baseDir, filename);
         if (filename && fs.existsSync(absolutePath)) {
           files[type][file].code = fs.readFileSync(absolutePath, 'utf-8');
+          files[type][file].entry = absolutePath === componentPaths[type];
+          files[type][file].path = getRelativePath(
+            path.dirname(componentPaths[type]),
+            absolutePath,
+          );
         } else {
           delete files[type][file];
         }

--- a/packages/plugin/src/markdown/utils/types.ts
+++ b/packages/plugin/src/markdown/utils/types.ts
@@ -1,4 +1,4 @@
-import { PlatformTemplate } from '../../constant/type';
+import { PlatformTemplate, PreviewFile } from '../../constant/type';
 import { Locale } from '@/locales/text';
 
 export interface DefaultProps {
@@ -27,7 +27,7 @@ export interface TabConfig {
   select?: string;
 }
 
-export type Files = Record<string, { code: string; filename: string }>;
+export type Files = Record<string, PreviewFile>;
 
 export type PreviewFiles = Record<'vue' | 'react' | 'html', Files>;
 


### PR DESCRIPTION
## Summary

- include supplemental demo source files when opening StackBlitz and CodeSandbox, preserving normalized relative paths
- standardize Vue and React playground entry components on `App.vue` and `App.tsx`
- keep per-demo platform options isolated from global config and update the bilingual preset docs

## Verification

- `pnpm --filter vitepress-demo-plugin build`
- `pnpm build:docs`
- `git diff --cached --check`