### PR TITLE
fix: isolate browser entry from Node modules

### DIFF
--- a/packages/docs/.vitepress/config.mts
+++ b/packages/docs/.vitepress/config.mts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vitepress';
-import { vitepressDemoPlugin } from 'vitepress-demo-plugin';
-import path, { dirname } from 'path';
+import { vitepressDemoPlugin } from 'vitepress-demo-plugin/markdown';
+import path, { dirname } from 'node:path';
 import { codeInspectorPlugin } from 'code-inspector-plugin';
 
 function fileURLToPath(fileURL: string) {

--- a/packages/docs/en/guide/advance.md
+++ b/packages/docs/en/guide/advance.md
@@ -23,8 +23,8 @@ Add following code into `config.ts`：
 
 ```ts
 import { defineConfig } from 'vitepress';
-import { vitepressDemoPlugin } from 'vitepress-demo-plugin';
-import path from 'path';
+import { vitepressDemoPlugin } from 'vitepress-demo-plugin/markdown';
+import path from 'node:path';
 
 export default defineConfig({
   // other configs...
@@ -102,8 +102,8 @@ If you want to make it effective for the global `<demo />` component, add the `t
 
 ```ts
 import { defineConfig } from 'vitepress';
-import { vitepressDemoPlugin } from 'vitepress-demo-plugin';
-import path from 'path';
+import { vitepressDemoPlugin } from 'vitepress-demo-plugin/markdown';
+import path from 'node:path';
 
 export default defineConfig({
   // other configs...
@@ -301,8 +301,8 @@ You can specify the code block themes in light mode and dark mode respectively t
 
 ```ts
 import { defineConfig } from 'vitepress';
-import { vitepressDemoPlugin } from 'vitepress-demo-plugin';
-import path from 'path';
+import { vitepressDemoPlugin } from 'vitepress-demo-plugin/markdown';
+import path from 'node:path';
 
 export default defineConfig({
   // other configs...
@@ -325,8 +325,8 @@ Example:
 
 ```ts
 import { defineConfig } from 'vitepress';
-import { vitepressDemoPlugin } from 'vitepress-demo-plugin';
-import path from 'path';
+import { vitepressDemoPlugin } from 'vitepress-demo-plugin/markdown';
+import path from 'node:path';
 
 export default defineConfig({
   // other configs...

--- a/packages/docs/en/guide/preset.md
+++ b/packages/docs/en/guide/preset.md
@@ -22,7 +22,7 @@ Add the following configuration in `.vitepress/config.ts` to take effect on all 
 
 ```ts
 import { defineConfig } from 'vitepress';
-import { vitepressDemoPlugin } from 'vitepress-demo-plugin';
+import { vitepressDemoPlugin } from 'vitepress-demo-plugin/markdown';
 
 export default defineConfig({
   // other configs...
@@ -419,7 +419,7 @@ When `scope` is set to `global`, it means that the template is effective for all
 
 ```ts
 import { defineConfig } from 'vitepress';
-import { vitepressDemoPlugin } from 'vitepress-demo-plugin';
+import { vitepressDemoPlugin } from 'vitepress-demo-plugin/markdown';
 
 export default defineConfig({
   // other configs...
@@ -452,7 +452,7 @@ When `scope` is set to `vue/react/html`, it means that the template is only vali
 
 ```ts
 import { defineConfig } from 'vitepress';
-import { vitepressDemoPlugin } from 'vitepress-demo-plugin';
+import { vitepressDemoPlugin } from 'vitepress-demo-plugin/markdown';
 
 export default defineConfig({
   // other configs...
@@ -492,7 +492,7 @@ You can also customize the name of `scope` to indicate that the template is only
 
 ```ts
 import { defineConfig } from 'vitepress';
-import { vitepressDemoPlugin } from 'vitepress-demo-plugin';
+import { vitepressDemoPlugin } from 'vitepress-demo-plugin/markdown';
 
 export default defineConfig({
   // other configs...
@@ -575,7 +575,7 @@ export type Playground = {
 
 ```ts
 import { defineConfig } from 'vitepress';
-import { vitepressDemoPlugin } from 'vitepress-demo-plugin';
+import { vitepressDemoPlugin } from 'vitepress-demo-plugin/markdown';
 
 export default defineConfig({
   // other configs...
@@ -608,7 +608,7 @@ If you want different demos to open in different playgrounds, you can provide mu
 
   ```ts
   import { defineConfig } from 'vitepress';
-  import { vitepressDemoPlugin } from 'vitepress-demo-plugin';
+  import { vitepressDemoPlugin } from 'vitepress-demo-plugin/markdown';
 
   export default defineConfig({
     // other configs...
@@ -636,7 +636,7 @@ If you want different demos to open in different playgrounds, you can provide mu
 
   ```ts
   import { defineConfig } from 'vitepress';
-  import { vitepressDemoPlugin } from 'vitepress-demo-plugin';
+  import { vitepressDemoPlugin } from 'vitepress-demo-plugin/markdown';
 
   export default defineConfig({
     // other configs...
@@ -665,7 +665,7 @@ If you want different demos to open in different playgrounds, you can provide mu
 
   ```ts
   import { defineConfig } from 'vitepress';
-  import { vitepressDemoPlugin } from 'vitepress-demo-plugin';
+  import { vitepressDemoPlugin } from 'vitepress-demo-plugin/markdown';
 
   const indexHtml = `
   <!DOCTYPE html>
@@ -736,7 +736,7 @@ If you want different demos to open in different playgrounds, you can provide mu
 
   ```ts
   import { defineConfig } from 'vitepress';
-  import { vitepressDemoPlugin } from 'vitepress-demo-plugin';
+  import { vitepressDemoPlugin } from 'vitepress-demo-plugin/markdown';
 
   const indexHtml = `
   <!DOCTYPE html>

--- a/packages/docs/en/guide/start.md
+++ b/packages/docs/en/guide/start.md
@@ -22,8 +22,8 @@ Add the following code to `.vitepress/config.ts` to import the `vitepressDemoPlu
 
 ```ts
 import { defineConfig } from 'vitepress';
-import { vitepressDemoPlugin } from 'vitepress-demo-plugin'; // [!code ++]
-import path from 'path';
+import { vitepressDemoPlugin } from 'vitepress-demo-plugin/markdown'; // [!code ++]
+import path from 'node:path';
 
 export default defineConfig({
   // other configs...

--- a/packages/docs/guide/advance.md
+++ b/packages/docs/guide/advance.md
@@ -23,8 +23,8 @@ docs
 
 ```ts
 import { defineConfig } from 'vitepress';
-import { vitepressDemoPlugin } from 'vitepress-demo-plugin';
-import path from 'path';
+import { vitepressDemoPlugin } from 'vitepress-demo-plugin/markdown';
+import path from 'node:path';
 
 export default defineConfig({
   // other configs...
@@ -102,8 +102,8 @@ export default defineConfig({
 
 ```ts
 import { defineConfig } from 'vitepress';
-import { vitepressDemoPlugin } from 'vitepress-demo-plugin';
-import path from 'path';
+import { vitepressDemoPlugin } from 'vitepress-demo-plugin/markdown';
+import path from 'node:path';
 
 export default defineConfig({
   // other configs...
@@ -300,8 +300,8 @@ export default {
 
 ```ts
 import { defineConfig } from 'vitepress';
-import { vitepressDemoPlugin } from 'vitepress-demo-plugin';
-import path from 'path';
+import { vitepressDemoPlugin } from 'vitepress-demo-plugin/markdown';
+import path from 'node:path';
 
 export default defineConfig({
   // other configs...
@@ -324,8 +324,8 @@ export default defineConfig({
 
 ```ts
 import { defineConfig } from 'vitepress';
-import { vitepressDemoPlugin } from 'vitepress-demo-plugin';
-import path from 'path';
+import { vitepressDemoPlugin } from 'vitepress-demo-plugin/markdown';
+import path from 'node:path';
 
 export default defineConfig({
   // other configs...

--- a/packages/docs/guide/preset.md
+++ b/packages/docs/guide/preset.md
@@ -22,7 +22,7 @@
 
 ```ts
 import { defineConfig } from 'vitepress';
-import { vitepressDemoPlugin } from 'vitepress-demo-plugin';
+import { vitepressDemoPlugin } from 'vitepress-demo-plugin/markdown';
 
 export default defineConfig({
   // other configs...
@@ -419,7 +419,7 @@ type Templates = Template[];
 
 ```ts
 import { defineConfig } from 'vitepress';
-import { vitepressDemoPlugin } from 'vitepress-demo-plugin';
+import { vitepressDemoPlugin } from 'vitepress-demo-plugin/markdown';
 
 export default defineConfig({
   // other configs...
@@ -452,7 +452,7 @@ export default defineConfig({
 
 ```ts
 import { defineConfig } from 'vitepress';
-import { vitepressDemoPlugin } from 'vitepress-demo-plugin';
+import { vitepressDemoPlugin } from 'vitepress-demo-plugin/markdown';
 
 export default defineConfig({
   // other configs...
@@ -492,7 +492,7 @@ export default defineConfig({
 
 ```ts
 import { defineConfig } from 'vitepress';
-import { vitepressDemoPlugin } from 'vitepress-demo-plugin';
+import { vitepressDemoPlugin } from 'vitepress-demo-plugin/markdown';
 
 export default defineConfig({
   // other configs...
@@ -574,7 +574,7 @@ export type Playground = {
 
 ```ts
 import { defineConfig } from 'vitepress';
-import { vitepressDemoPlugin } from 'vitepress-demo-plugin';
+import { vitepressDemoPlugin } from 'vitepress-demo-plugin/markdown';
 
 export default defineConfig({
   // other configs...
@@ -607,7 +607,7 @@ export default defineConfig({
 
   ```ts
   import { defineConfig } from 'vitepress';
-  import { vitepressDemoPlugin } from 'vitepress-demo-plugin';
+  import { vitepressDemoPlugin } from 'vitepress-demo-plugin/markdown';
 
   export default defineConfig({
     // other configs...
@@ -634,7 +634,7 @@ export default defineConfig({
 - 新增加一个名为 `codeplayer` 的 config，并且自定义 `url`
   ```ts
   import { defineConfig } from 'vitepress';
-  import { vitepressDemoPlugin } from 'vitepress-demo-plugin';
+  import { vitepressDemoPlugin } from 'vitepress-demo-plugin/markdown';
 
   export default defineConfig({
     // other configs...
@@ -662,7 +662,7 @@ export default defineConfig({
 - 按照 [codeplayer](https://play.fe-dev.cn/) 平台的格式，增加 `codeplayer` 的 scope:
   ```ts
   import { defineConfig } from 'vitepress';
-  import { vitepressDemoPlugin } from 'vitepress-demo-plugin';
+  import { vitepressDemoPlugin } from 'vitepress-demo-plugin/markdown';
 
   const indexHtml = `
   <!DOCTYPE html>
@@ -732,7 +732,7 @@ export default defineConfig({
 - 按照 [codeplayer 平台的序列化格式](https://play.fe-dev.cn/docs/guide/start.html)，自定义 `fn` 函数：
   ```ts
   import { defineConfig } from 'vitepress';
-  import { vitepressDemoPlugin } from 'vitepress-demo-plugin';
+  import { vitepressDemoPlugin } from 'vitepress-demo-plugin/markdown';
 
   const indexHtml = `
   <!DOCTYPE html>

--- a/packages/docs/guide/start.md
+++ b/packages/docs/guide/start.md
@@ -22,8 +22,8 @@ pnpm add vitepress-demo-plugin -D
 
 ```ts
 import { defineConfig } from 'vitepress';
-import { vitepressDemoPlugin } from 'vitepress-demo-plugin'; // [!code ++]
-import path from 'path';
+import { vitepressDemoPlugin } from 'vitepress-demo-plugin/markdown'; // [!code ++]
+import path from 'node:path';
 
 export default defineConfig({
   // other configs...

--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -13,6 +13,7 @@
 
 </div>
 
+
 <hr />
 
 ## 📖 介绍
@@ -45,8 +46,8 @@ pnpm add vitepress-demo-plugin -D
 
   ```ts
   import { defineConfig } from 'vitepress';
-  import { vitepressDemoPlugin } from 'vitepress-demo-plugin'; 
-  import path from 'path';
+  import { vitepressDemoPlugin } from 'vitepress-demo-plugin/markdown';
+  import path from 'node:path';
 
   export default defineConfig({
     // other configs...
@@ -81,4 +82,3 @@ pnpm add vitepress-demo-plugin -D
   <img src="https://cdn.jsdelivr.net/gh/zh-lx/static-img/vitepress-demo-plugin/wx-group.jpg" width="200" height="272" />
   <img src="https://cdn.jsdelivr.net/gh/zh-lx/static-img/code-inspector/wx-qrcode.jpg" width="200" height="272" />
 </div>
-

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -25,8 +25,8 @@
     ".": {
       "types": "./dist/index.d.ts",
       "browser": {
-        "import": "./dist/client.js",
-        "require": "./dist/client.cjs"
+        "import": "./dist/browser.js",
+        "require": "./dist/browser.cjs"
       },
       "import": "./dist/index.js",
       "require": "./dist/index.umd.cjs"
@@ -46,7 +46,7 @@
   },
   "main": "./dist/index.umd.cjs",
   "module": "./dist/index.js",
-  "browser": "./dist/client.js",
+  "browser": "./dist/browser.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -23,13 +23,30 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
+      "browser": {
+        "import": "./dist/client.js",
+        "require": "./dist/client.cjs"
+      },
       "import": "./dist/index.js",
       "require": "./dist/index.umd.cjs"
     },
+    "./client": {
+      "types": "./dist/client.d.ts",
+      "import": "./dist/client.js",
+      "require": "./dist/client.cjs"
+    },
+    "./markdown": {
+      "types": "./dist/markdown.d.ts",
+      "import": "./dist/markdown.js",
+      "require": "./dist/markdown.cjs"
+    },
+    "./style.css": "./dist/style.css",
     "./dist/style.css": "./dist/style.css"
   },
   "main": "./dist/index.umd.cjs",
   "module": "./dist/index.js",
+  "browser": "./dist/client.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/plugin/src/browser.ts
+++ b/packages/plugin/src/browser.ts
@@ -1,0 +1,9 @@
+type VitepressDemoPlugin = typeof import('./markdown').vitepressDemoPlugin;
+
+export { VitepressDemoBox, VitepressDemoPlaceholder } from './client';
+
+export const vitepressDemoPlugin: VitepressDemoPlugin = () => {
+  throw new Error(
+    '[vitepress-demo-plugin] vitepressDemoPlugin is only available in Node.js. Import it from "vitepress-demo-plugin/markdown" in your VitePress config.',
+  );
+};

--- a/packages/plugin/src/client.ts
+++ b/packages/plugin/src/client.ts
@@ -1,0 +1,4 @@
+import VitepressDemoBox from './components/index.vue';
+import VitepressDemoPlaceholder from './components/placeholder.vue';
+
+export { VitepressDemoBox, VitepressDemoPlaceholder };

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -1,5 +1,2 @@
-import VitepressDemoBox from './components/index.vue';
-import VitepressDemoPlaceholder from './components/placeholder.vue';
-
 export { vitepressDemoPlugin } from './markdown';
-export { VitepressDemoBox, VitepressDemoPlaceholder };
+export { VitepressDemoBox, VitepressDemoPlaceholder } from './client';

--- a/packages/plugin/src/markdown/preview.ts
+++ b/packages/plugin/src/markdown/preview.ts
@@ -1,6 +1,6 @@
 import MarkdownIt from 'markdown-it';
 import Token from 'markdown-it/lib/token';
-import path from 'path';
+import path from 'node:path';
 import {
   composeComponentName,
   createPlaygroundUrls,
@@ -126,10 +126,10 @@ export const transformPreview = (
   // 注入 vitepress-demo-plugin 组件和样式
   injectComponentImportScript(
     mdFile,
-    'vitepress-demo-plugin',
+    'vitepress-demo-plugin/client',
     `{ VitepressDemoBox, VitepressDemoPlaceholder }`,
   );
-  injectComponentImportScript(mdFile, 'vitepress-demo-plugin/dist/style.css');
+  injectComponentImportScript(mdFile, 'vitepress-demo-plugin/style.css');
   injectComponentImportScript(mdFile, 'vue', '{ ref, shallowRef, onMounted }');
 
   // 注入组件导入语句

--- a/packages/plugin/src/markdown/utils/files.ts
+++ b/packages/plugin/src/markdown/utils/files.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 import { PreviewFiles } from './types';
 
 type ComponentPaths = Record<keyof PreviewFiles, string>;

--- a/packages/plugin/src/markdown/utils/playground.ts
+++ b/packages/plugin/src/markdown/utils/playground.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 import { getAbsolutePath, getRelativePath } from './files';
 import { Playground, PreviewFiles } from './types';
 

--- a/packages/plugin/vite.config.ts
+++ b/packages/plugin/vite.config.ts
@@ -1,7 +1,51 @@
-import { defineConfig } from 'vite';
-import { resolve } from 'path';
+import { defineConfig, type Plugin } from 'vite';
+import { resolve } from 'node:path';
 import vue from '@vitejs/plugin-vue';
 import dts from 'vite-plugin-dts';
+
+const assertClientBoundary = (): Plugin => ({
+  name: 'assert-client-boundary',
+  generateBundle(_, bundle) {
+    const clientEntry = Object.values(bundle).find(
+      (output) =>
+        output.type === 'chunk' &&
+        output.facadeModuleId?.replace(/\\/g, '/').endsWith('/src/client.ts'),
+    );
+    if (!clientEntry || clientEntry.type !== 'chunk') {
+      this.error('Unable to find the client entry chunk.');
+    }
+
+    const forbiddenImports = new Set([
+      'fs',
+      'path',
+      'node:fs',
+      'node:path',
+      'markdown-it',
+    ]);
+    const pending = [clientEntry!.fileName];
+    const visited = new Set<string>();
+    while (pending.length) {
+      const fileName = pending.pop()!;
+      if (visited.has(fileName)) {
+        continue;
+      }
+      visited.add(fileName);
+
+      const output = bundle[fileName];
+      if (!output || output.type !== 'chunk') {
+        continue;
+      }
+      for (const imported of [...output.imports, ...output.dynamicImports]) {
+        if (forbiddenImports.has(imported)) {
+          this.error(`Client output must not import "${imported}".`);
+        }
+        if (bundle[imported]?.type === 'chunk') {
+          pending.push(imported);
+        }
+      }
+    }
+  },
+});
 
 export default defineConfig(() => {
   // 判断是否是 --watch 模式
@@ -10,29 +54,31 @@ export default defineConfig(() => {
   return {
     build: {
       lib: {
-        entry: resolve(__dirname, './src/index.ts'),
+        entry: {
+          index: resolve(__dirname, './src/index.ts'),
+          client: resolve(__dirname, './src/client.ts'),
+          markdown: resolve(__dirname, './src/markdown/index.ts'),
+        },
         name: 'demoBox',
-        fileName: 'index',
+        formats: ['es', 'cjs'],
+        fileName: (format, entryName) => {
+          if (format === 'es') {
+            return `${entryName}.js`;
+          }
+          return entryName === 'index' ? 'index.umd.cjs' : `${entryName}.cjs`;
+        },
       },
       rollupOptions: {
         external: [
           'vue',
           'markdown-it',
-          'fs',
-          'path',
+          'node:fs',
+          'node:path',
           'react',
           'react-dom',
           'sass',
           'shiki',
         ],
-        output: {
-          globals: {
-            vue: 'Vue',
-            fs: 'fs',
-            path: 'path',
-            shiki: 'shiki',
-          },
-        },
       },
       emptyOutDir: !isWatchMode,
     },
@@ -42,9 +88,10 @@ export default defineConfig(() => {
       },
     },
     plugins: [
+      assertClientBoundary(),
       vue(),
       dts({
-        entryRoot: 'src/markdown',
+        entryRoot: 'src',
         rollupTypes: true,
         strictOutput: true,
       }),

--- a/packages/plugin/vite.config.ts
+++ b/packages/plugin/vite.config.ts
@@ -6,15 +6,6 @@ import dts from 'vite-plugin-dts';
 const assertClientBoundary = (): Plugin => ({
   name: 'assert-client-boundary',
   generateBundle(_, bundle) {
-    const clientEntry = Object.values(bundle).find(
-      (output) =>
-        output.type === 'chunk' &&
-        output.facadeModuleId?.replace(/\\/g, '/').endsWith('/src/client.ts'),
-    );
-    if (!clientEntry || clientEntry.type !== 'chunk') {
-      this.error('Unable to find the client entry chunk.');
-    }
-
     const forbiddenImports = new Set([
       'fs',
       'path',
@@ -22,7 +13,32 @@ const assertClientBoundary = (): Plugin => ({
       'node:path',
       'markdown-it',
     ]);
-    const pending = [clientEntry!.fileName];
+    const isForbiddenModule = (moduleId: string) => {
+      const normalizedId = moduleId.replace(/\\/g, '/');
+      return (
+        forbiddenImports.has(normalizedId) ||
+        normalizedId.includes('/src/markdown/') ||
+        /\/node_modules\/(fs|path|markdown-it)(\/|$)/.test(normalizedId)
+      );
+    };
+
+    const browserEntries = ['/src/client.ts', '/src/browser.ts'].map(
+      (entrySuffix) => {
+        const entry = Object.values(bundle).find(
+          (output) =>
+            output.type === 'chunk' &&
+            output.facadeModuleId
+              ?.replace(/\\/g, '/')
+              .endsWith(entrySuffix),
+        );
+        if (!entry || entry.type !== 'chunk') {
+          this.error(`Unable to find the ${entrySuffix} entry chunk.`);
+        }
+        return entry.fileName;
+      },
+    );
+
+    const pending = [...browserEntries];
     const visited = new Set<string>();
     while (pending.length) {
       const fileName = pending.pop()!;
@@ -35,9 +51,14 @@ const assertClientBoundary = (): Plugin => ({
       if (!output || output.type !== 'chunk') {
         continue;
       }
+      for (const moduleId of Object.keys(output.modules)) {
+        if (isForbiddenModule(moduleId)) {
+          this.error(`Browser output must not include "${moduleId}".`);
+        }
+      }
       for (const imported of [...output.imports, ...output.dynamicImports]) {
         if (forbiddenImports.has(imported)) {
-          this.error(`Client output must not import "${imported}".`);
+          this.error(`Browser output must not import "${imported}".`);
         }
         if (bundle[imported]?.type === 'chunk') {
           pending.push(imported);
@@ -57,6 +78,7 @@ export default defineConfig(() => {
         entry: {
           index: resolve(__dirname, './src/index.ts'),
           client: resolve(__dirname, './src/client.ts'),
+          browser: resolve(__dirname, './src/browser.ts'),
           markdown: resolve(__dirname, './src/markdown/index.ts'),
         },
         name: 'demoBox',


### PR DESCRIPTION
## Summary

- split browser components and the Markdown plugin into dedicated `client` and `markdown` package entries
- route browser resolution and generated demo imports through the Node-free client entry while retaining the legacy root entry
- use explicit `node:fs` and `node:path` imports and add a build-time client dependency boundary check
- update package exports and documentation for the new entry points

## Verification

- `pnpm --dir packages/plugin build`
- `pnpm build:docs` with VitePress 1.6.3
- VitePress 2.0.0-alpha.17 build in a temporary pnpm workspace containing `path@0.12.7`
- ESM, CJS, conditional browser exports, and the legacy root entry

Closes #111